### PR TITLE
Binding produces truncated hashes due to type mismatch

### DIFF
--- a/mhashlib/api.py
+++ b/mhashlib/api.py
@@ -41,7 +41,7 @@ try:
 
     lib.mhash.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
     lib.mhash_end.argtypes = [ctypes.c_void_p]
-    lib.mhash_end.restype = ctypes.c_char_p
+    lib.mhash_end.restype = ctypes.c_void_p
 
     lib.mhash_get_block_size.argtypes = [ctypes.c_int]
     lib.mhash_get_block_size.restype = ctypes.c_int

--- a/mhashlib/base.py
+++ b/mhashlib/base.py
@@ -2,6 +2,7 @@
 
 from . import api
 import binascii
+import ctypes
 
 class BaseHash(object):
     _hash_type = None
@@ -32,9 +33,8 @@ class BaseHash(object):
             return self._result
 
         size = api.lib.mhash_get_block_size(self._hash_type)
-        self._result = api.lib.mhash_end(self.td)
-        if len(self._result) > size:
-            self._result = self._result[:size]
+        cvp = api.lib.mhash_end(self.td)
+        self._result = ctypes.cast(cvp, ctypes.POINTER(ctypes.c_char))[:size]
 
         return self._result
 

--- a/tests.py
+++ b/tests.py
@@ -61,3 +61,9 @@ class MHashlibTest(unittest.TestCase):
         hash = mhashlib.snefru256(self.sample_data)
         valid_digest = b'f33eb2a3152af27e719474e8888da43c53b1ea7a629796eb7a67ecc539fc29a8'
         self.assertEqual(valid_digest, hash.hexdigest())
+
+    def test_binary_conversion(self):
+        hash = mhashlib.tiger192("gsadghas").digest()
+        valid_digest = b'8e9ce14e903592a2bc89456d6c2487d300ab05a3f2f67ca7'
+        self.assertEqual(valid_digest, hash.hexdigest())
+


### PR DESCRIPTION
Hi, I just ran in to a really annoying bug with your code.

The problem specifically is this line in api.py:
    lib.mhash_end.restype = ctypes.c_char_p

Ctypes transparently converts c_char_p returns to strings and blindly assumes them to be null terminated strings.  Per the docs, c_char_p shouldn't be used for binary data.
This does, unfortunately, complicate things as you can't access c_void_p directly.

I can only assume that the len() > size check is there because the strings not being null terminated meant you were getting random string lengths back.
